### PR TITLE
feat: Question & Answer 조회 시, comments 함께 조회되도록 추가 기능 구현

### DIFF
--- a/server/src/main/java/com/lucky7/preproject/answer/controller/AnswerController.java
+++ b/server/src/main/java/com/lucky7/preproject/answer/controller/AnswerController.java
@@ -1,10 +1,13 @@
 package com.lucky7.preproject.answer.controller;
 
 import com.lucky7.preproject.answer.dto.requestDto.AnswerDto;
+import com.lucky7.preproject.answer.dto.responseDto.AnswerCommentDto;
 import com.lucky7.preproject.answer.dto.responseDto.AnswerResponseDto;
 import com.lucky7.preproject.answer.entity.Answer;
 import com.lucky7.preproject.answer.mapper.AnswerMapper;
 import com.lucky7.preproject.answer.service.AnswerService;
+import com.lucky7.preproject.comment.entity.AnswerComment;
+import com.lucky7.preproject.comment.service.AnswerCommentService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +24,7 @@ public class AnswerController {
 
     private final AnswerService answerService;
     private final AnswerMapper answerMapper;
+    private final AnswerCommentService answerCommentService;
 
     @PostMapping
     public ResponseEntity<AnswerResponseDto> postAnswer(@PathVariable long questionId,
@@ -36,6 +40,12 @@ public class AnswerController {
     public ResponseEntity<List<AnswerResponseDto>> getAllAnswers(@PathVariable long questionId) {
         List<Answer> foundAnswers = answerService.getAllAnswers(questionId);
         List<AnswerResponseDto> responseDtos = answerMapper.answersToAnswerDtos(foundAnswers);
+
+        for(AnswerResponseDto answerResponseDto : responseDtos) {
+            List<AnswerComment> answerComments = answerCommentService.findAnswerComments(answerResponseDto.getAnswerId());
+            List<AnswerCommentDto> answerCommentDtos = answerMapper.answerCommentsToAnswerCommentDtos(answerComments);
+            answerResponseDto.setAnswerComments(answerCommentDtos);
+        }
 
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }

--- a/server/src/main/java/com/lucky7/preproject/answer/dto/responseDto/AnswerCommentDto.java
+++ b/server/src/main/java/com/lucky7/preproject/answer/dto/responseDto/AnswerCommentDto.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
-public class CommentDto {
+public class AnswerCommentDto {
     private Long commentUser;
     private String commentContent;
     private LocalDateTime createdAt;

--- a/server/src/main/java/com/lucky7/preproject/answer/dto/responseDto/AnswerResponseDto.java
+++ b/server/src/main/java/com/lucky7/preproject/answer/dto/responseDto/AnswerResponseDto.java
@@ -1,5 +1,6 @@
 package com.lucky7.preproject.answer.dto.responseDto;
 
+import com.lucky7.preproject.comment.entity.AnswerComment;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,5 +15,5 @@ public class AnswerResponseDto {
     private String answerUser;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
-    private List<CommentDto> answerComments;
+    private List<AnswerCommentDto> answerComments;
 }

--- a/server/src/main/java/com/lucky7/preproject/answer/mapper/AnswerMapper.java
+++ b/server/src/main/java/com/lucky7/preproject/answer/mapper/AnswerMapper.java
@@ -1,8 +1,10 @@
 package com.lucky7.preproject.answer.mapper;
 
 import com.lucky7.preproject.answer.dto.requestDto.AnswerDto;
+import com.lucky7.preproject.answer.dto.responseDto.AnswerCommentDto;
 import com.lucky7.preproject.answer.dto.responseDto.AnswerResponseDto;
 import com.lucky7.preproject.answer.entity.Answer;
+import com.lucky7.preproject.comment.entity.AnswerComment;
 import org.mapstruct.Mapper;
 
 import java.util.List;
@@ -12,4 +14,5 @@ public interface AnswerMapper {
     AnswerResponseDto answerToAnswerDto(Answer answer);
     Answer answerDtoToAnswer(AnswerDto answerDto);
     List<AnswerResponseDto> answersToAnswerDtos(List<Answer> answers);
+    List<AnswerCommentDto> answerCommentsToAnswerCommentDtos(List<AnswerComment> answerComments);
 }

--- a/server/src/main/java/com/lucky7/preproject/answer/service/AnswerService.java
+++ b/server/src/main/java/com/lucky7/preproject/answer/service/AnswerService.java
@@ -57,6 +57,7 @@ public class AnswerService {
 
     public Answer getAnswer(long answerId) {
         Answer defaultAnswer = new Answer();
+
         return answerRepository.findById(answerId).orElse(defaultAnswer);
     }
 

--- a/server/src/main/java/com/lucky7/preproject/question/controller/QuestionController.java
+++ b/server/src/main/java/com/lucky7/preproject/question/controller/QuestionController.java
@@ -1,7 +1,10 @@
 package com.lucky7.preproject.question.controller;
 
+import com.lucky7.preproject.comment.entity.QuestionComment;
+import com.lucky7.preproject.comment.service.QuestionCommentService;
 import com.lucky7.preproject.question.dto.requestDto.QuestionDto;
 import com.lucky7.preproject.question.dto.responseDto.AllQuestionsResponseDto;
+import com.lucky7.preproject.question.dto.responseDto.QuestionCommentDto;
 import com.lucky7.preproject.question.dto.responseDto.SingleQuestionResponseDto;
 import com.lucky7.preproject.question.entity.Question;
 import com.lucky7.preproject.question.mapper.QuestionMapper;
@@ -27,6 +30,7 @@ public class QuestionController {
     private final QuestionService questionService;
     private final QuestionMapper mapper;
     private final UserService userService;
+    private final QuestionCommentService questionCommentService;
 
     @PostMapping
     public ResponseEntity<SingleQuestionResponseDto> postQuestion(@RequestBody QuestionDto questionDto) {
@@ -60,6 +64,10 @@ public class QuestionController {
 
         Question foundQuestion = questionService.getQuestion(questionId);
         SingleQuestionResponseDto responseDto = mapper.questionToSingleQuestionResponseDto(foundQuestion);
+
+        List<QuestionComment> questionComments = questionCommentService.findQuestionComments(questionId);
+        List<QuestionCommentDto> questionCommentDtos = mapper.questionCommentsDtos(questionComments);
+        responseDto.setQuestionComments(questionCommentDtos);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/server/src/main/java/com/lucky7/preproject/question/dto/responseDto/QuestionCommentDto.java
+++ b/server/src/main/java/com/lucky7/preproject/question/dto/responseDto/QuestionCommentDto.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 // 질문 1개 조회 시 함께 조회할 댓글에 대한 정보입니다.
 // 질문에 대한 댓글 C,U,D는 CommentController 작성 시에 구현할 예정입니다.
-public class CommentDto {
+public class QuestionCommentDto {
     private String commentUser;
     private String commentContent;
     private String createdAt;

--- a/server/src/main/java/com/lucky7/preproject/question/dto/responseDto/SingleQuestionResponseDto.java
+++ b/server/src/main/java/com/lucky7/preproject/question/dto/responseDto/SingleQuestionResponseDto.java
@@ -1,5 +1,7 @@
 package com.lucky7.preproject.question.dto.responseDto;
 
+import com.lucky7.preproject.comment.entity.AnswerComment;
+import com.lucky7.preproject.comment.entity.QuestionComment;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,5 +17,5 @@ public class SingleQuestionResponseDto {
     private String questionUser;
     private LocalDateTime createdAt;
     private LocalDateTime lastModifiedAt;
-    private List<CommentDto> questionComments;   // CommentDto 생성 후에 담아줄 예정
+    private List<QuestionCommentDto> questionComments;
 }

--- a/server/src/main/java/com/lucky7/preproject/question/mapper/QuestionMapper.java
+++ b/server/src/main/java/com/lucky7/preproject/question/mapper/QuestionMapper.java
@@ -1,10 +1,14 @@
 package com.lucky7.preproject.question.mapper;
 
+import com.lucky7.preproject.comment.entity.QuestionComment;
 import com.lucky7.preproject.question.dto.requestDto.QuestionDto;
 import com.lucky7.preproject.question.dto.responseDto.AllQuestionsResponseDto;
+import com.lucky7.preproject.question.dto.responseDto.QuestionCommentDto;
 import com.lucky7.preproject.question.dto.responseDto.SingleQuestionResponseDto;
 import com.lucky7.preproject.question.entity.Question;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring") // Spring 의 Bean 으로 등록
 public interface QuestionMapper {
@@ -12,4 +16,5 @@ public interface QuestionMapper {
     Question questionPatchDtoToQuestion(QuestionDto questionDto);
     SingleQuestionResponseDto questionToSingleQuestionResponseDto(Question question);
     AllQuestionsResponseDto questionToAllQuestionResponseDto(Question question);
+    List<QuestionCommentDto> questionCommentsDtos(List<QuestionComment> questionComments);
 }

--- a/server/src/main/java/com/lucky7/preproject/question/service/QuestionService.java
+++ b/server/src/main/java/com/lucky7/preproject/question/service/QuestionService.java
@@ -1,5 +1,7 @@
 package com.lucky7.preproject.question.service;
 
+import com.lucky7.preproject.comment.entity.QuestionComment;
+import com.lucky7.preproject.comment.service.QuestionCommentService;
 import com.lucky7.preproject.question.entity.Question;
 import com.lucky7.preproject.question.repository.QuestionRepository;
 import com.lucky7.preproject.user.repository.UserRepository;
@@ -14,6 +16,8 @@ import java.util.Optional;
 @AllArgsConstructor
 public class QuestionService {
     private final QuestionRepository questionRepository;
+    // 추후 트랜잭션 구현을 위해 레포지토리가 아닌 서비스에서 DI를 받습니다.
+    private final QuestionCommentService questionCommentService;
 
     /**
      *     서비스에서의 목적은 비즈니스 로직을 처리하는 것 입니다.
@@ -38,9 +42,9 @@ public class QuestionService {
         // 예외처리 로직 추가 필요 (존재하지 않는 질문을 조회할 경우)
         // ex) EntityNotFoundException (orElseThrow 사용 등의 방법이 있습니다.)
         Question defaultQuestion = new Question();
+
         return questionRepository.findById(questionId).orElse(defaultQuestion);
     }
-
 
     @PreAuthorize("hasRole('USER') and #question.userId == principal.id")
     public Question updateQuestion(long questionId, Question questionToUpdate) {


### PR DESCRIPTION
Queestion & Answer 컨트롤러, 서비스에 AnswerComments, QuestionComments 함께 조회되도록 추가했습니다.
테스트 완료했습니다.

Resolves: #13 , #5 