### PR TITLE
fix: Header에 Access-Control-Expose-Headers 추가

### DIFF
--- a/server/src/main/java/com/lucky7/preproject/auth/fiter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/lucky7/preproject/auth/fiter/JwtAuthenticationFilter.java
@@ -58,6 +58,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("Refresh", refreshToken);
+        response.setHeader("Access-Control-Expose-Headers", "Authorization");
 
         log.info("# successfulAuthentication");
 


### PR DESCRIPTION
auth > filter > JwtAuthenticationFilter 에 웹 브라우저 클라이언트가 Headers 값 읽을 수 있도록 추가 구현